### PR TITLE
fix the  unexpected '::' (T_PAAMAYIM_NEKUDOTAYIM) syntax error in SwooleWebSocketWrapper

### DIFF
--- a/src/Wrapper/SwooleWebSocketWrapper.php
+++ b/src/Wrapper/SwooleWebSocketWrapper.php
@@ -153,7 +153,8 @@ class SwooleWebSocketWrapper extends SwooleHttpWrapper implements ServerInterfac
         if (!$frame->finish) {
             return;
         }
-        $data = $this->connections[$frame->fd]['protocol']::decode($this->unfinished[$frame->fd]);
+        $protocol = $this->connections[$frame->fd]['protocol'];
+        $data = $protocol::decode($this->unfinished[$frame->fd]);
         if (is_null($data)) {
             return;
         }
@@ -196,7 +197,8 @@ class SwooleWebSocketWrapper extends SwooleHttpWrapper implements ServerInterfac
     {
         if (isset($response->request)) {
             // This is a websocket request
-            $data = $this->connections[$response->request->fd]['protocol']::encode(
+            $protocol = $this->connections[$response->request->fd]['protocol'];
+            $data = $protocol::encode(
                 $response->http_status,
                 $response->request->method,
                 $content,


### PR DESCRIPTION
```php
   $data = $this->connections[$frame->fd]['protocol']::decode($this->unfinished[$frame->fd]);
```
Calling a static method on class property is invalid in php (php7 or above don't have this problem).

a relative topic has been discussed here.
http://stackoverflow.com/questions/33198432/php-calling-static-method-on-class-property
