### PR TITLE
support log level

### DIFF
--- a/src/Wrapper/Swoole.php
+++ b/src/Wrapper/Swoole.php
@@ -28,6 +28,7 @@ abstract class Swoole extends Base
             'daemonize' => 1,
             'backlog',
             'log_file' => [self::class, 'getLogFile'],
+            'log_level',
             'heartbeat_check_interval',
             'heartbeat_idle_time',
             'open_eof_check',


### PR DESCRIPTION
Sometimes, we need to ignore low-level logs.