### PR TITLE
Support laravel5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,12 @@
             "Laravoole\\": "src/",
             "Laravoole\\Test\\": "tests/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Laravoole\\LaravooleServiceProvider"
+            ]
+        }
     }
 }

--- a/src/Base.php
+++ b/src/Base.php
@@ -70,9 +70,10 @@ abstract class Base
             spl_autoload_unregister($function);
         }
 
-        if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-            require __DIR__ . '/../vendor/autoload.php';
-        } else {
+        if (file_exists(__DIR__ . '/../../../autoload.php')) {
+            require __DIR__ . '/../../../autoload.php';
+        } elseif (file_exists($this->root_dir . '/bootstrap/autoload.php')) {
+            //as of laravel>=5.5, optimize command has been deprecated
             require $this->root_dir . '/bootstrap/autoload.php';
         }
         if (isset($this->base_config['callbacks']['bootstraping'])) {

--- a/src/Base.php
+++ b/src/Base.php
@@ -70,7 +70,9 @@ abstract class Base
             spl_autoload_unregister($function);
         }
 
-        if (file_exists(__DIR__ . '/../../../autoload.php')) {
+        if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+            require __DIR__ . '/../vendor/autoload.php';
+        } elseif (file_exists(__DIR__.'/../../../autoload.php')) {
             require __DIR__ . '/../../../autoload.php';
         } elseif (file_exists($this->root_dir . '/bootstrap/autoload.php')) {
             //as of laravel>=5.5, optimize command has been deprecated

--- a/src/Commands/LaravooleCommand.php
+++ b/src/Commands/LaravooleCommand.php
@@ -21,7 +21,7 @@ class LaravooleCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Start laravoole';
+    protected $description = 'Laravoole control utilities';
 
     /**
      * Create a new command instance.
@@ -34,11 +34,21 @@ class LaravooleCommand extends Command
     }
 
     /**
+     * Execute the console command before Laravel < 5.5.
+     * 
+     * @return mixed
+     */
+    public function fire()
+    {
+        $this->handle();
+    }
+
+    /**
      * Execute the console command.
      *
      * @return mixed
      */
-    public function fire()
+    public function handle()
     {
         switch ($action = $this->argument('action')) {
 


### PR DESCRIPTION
Hi, @garveen , this PR contains three updates:

- Support Laravel5.5 
- Support Package Auto Discovery
- Change command description from `Start laravoole` to `Laravoole control utilities`